### PR TITLE
feat: add config options and refactor to modular shell scripts

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,7 +12,8 @@
     {
       "description": "Update GitHub Actions with SHA pins",
       "matchManagers": ["github-actions"],
-      "matchPackagePatterns": ["^actions/"]
+      "matchPackageNames": ["^actions/"],
+      "pinDigests": true
     }
   ]
 }

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,10 +4,15 @@
   "dependencyDashboard": true,
   "automerge": true,
   "packageRules": [
-      {
+    {
       "description": "Automerge non-major updates",
       "matchUpdateTypes": ["minor", "patch", "digest"],
       "automerge": true
+    },
+    {
+      "description": "Update GitHub Actions with SHA pins",
+      "matchManagers": ["github-actions"],
+      "matchPackagePatterns": ["^actions/"]
     }
   ]
 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: Install bats
-        run: npm install -g bats
+        run: sudo apt-get update && sudo apt-get install -y bats
 
       - name: Run validation tests
         run: bats tests/validate_test.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,47 @@
+name: Test and Lint
+
+on:
+  push:
+    branches: [master, main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    name: ShellCheck
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Run ShellCheck
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38
+        with:
+          ignore_paths: .git
+
+  bats:
+    name: BATS Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          persist-credentials: false
+
+      - name: Install bats
+        run: npm install -g bats
+
+      - name: Run validation tests
+        run: bats tests/validate_test.sh
+
+      - name: Run build-args tests
+        run: bats tests/build_args_test.sh
+
+      - name: Run SARIF fix tests
+        run: bats tests/fix_sarif_test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Test artifacts
+tests/*.tap
+*.tmp
+
+# IDE
+.vscode/
+.idea/
+
+# OS
+.DS_Store

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,3 @@
+# ShellCheck configuration for govulncheck-action
+# Follow sourced files in src/ directory
+source=src/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to Go
 
 Go is an open source project.
-
-It is the work of hundreds of contributors. We appreciate your help!
+It is the work of hundreds of contributors.
+We appreciate your help!
 
 ## Filing issues
 
@@ -19,8 +19,6 @@ The gophers there will answer or ask you to file an issue if you've tripped over
 
 ## Contributing code
 
-Please read the [Contribution Guidelines](https://go.dev/doc/contribute.html)
-before sending patches.
+Please read the [Contribution Guidelines](https://go.dev/doc/contribute.html) before sending patches.
 
-Unless otherwise noted, the Go source files are distributed under
-the BSD-style license found in the LICENSE file.
+Unless otherwise noted, the Go source files are distributed under the BSD-style license found in the LICENSE file.

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ jobs:
           output-format: sarif
           output-file: results.sarif
 
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif
 ```
@@ -248,7 +248,7 @@ jobs:
           output-format: sarif
           output-file: results.sarif
 
-      - uses: github/codeql-action/upload-sarif@v3
+      - uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: results.sarif
 ```

--- a/README.md
+++ b/README.md
@@ -105,11 +105,11 @@ The `scan-level` input controls the detail level of the vulnerability analysis:
 
 The `mode` input specifies how to analyze the code:
 
-| Mode      | Description                                           |
-|-----------|-------------------------------------------------------|
-| `source`  | Analyze source code (default)                         |
-| `binary`  | Analyze a compiled binary (requires pre-built binary) |
-| `extract` | Extract information from binary for later analysis    |
+| Mode      | Description                                             |
+|-----------|---------------------------------------------------------|
+| `source`  | Analyze source code (default)                           |
+| `binary`  | Analyze a compiled binary (requires a pre-built binary) |
+| `extract` | Extract information from binary for later analysis      |
 
 #### Binary Mode
 

--- a/README.md
+++ b/README.md
@@ -1,79 +1,180 @@
-# GitHub Action for govulncheck
+# govulncheck-action
 
-[Govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) provides a low-noise, reliable way for Go users to learn about known vulnerabilities that may affect their dependencies.
-See details on [Go's support for vulnerability management](https://go.dev/blog/vuln).
+A GitHub Action that runs [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) to detect known vulnerabilities in Go dependencies.
 
-## Usage
+This action uses **static analysis** to identify only those vulnerabilities that could actually affect your application, reducing noise from irrelevant findings.
 
-To use the govulncheck GitHub Action add the following step to your workflow:
+For detailed information about govulncheck's capabilities, flags, and limitations, see the [official govulncheck documentation](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck).
 
-  ```yaml
-  - id: govulncheck
-    uses: nicholas-fedor/govulncheck-action@master
-  ```
+## Quick Start
 
-By default the govulncheck Github Action will run with the [latest version of Go](https://go.dev/doc/install) and analyze all packages in the provided Go module.
+```yaml
+name: Run Go Security Check
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
-To run `govulncheck` locally:
+env:
+  OUTPUT_FILE: results.sarif
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Run govulncheck
+        uses: nicholas-fedor/govulncheck-action@master
+        with:
+          output-format: sarif
+          output-file: ${{ env.OUTPUT_FILE }}
+          go-version-file: "go.mod"
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: ${{ env.OUTPUT_FILE }}
+```
+
+## Running Locally
+
+To run `govulncheck` locally before using the action:
 
 1. Install govulncheck:
 
-    ```bash
-    go install golang.org/x/vuln/cmd/govulncheck@latest
-    ```
+   ```bash
+   go install golang.org/x/vuln/cmd/govulncheck@latest
+   ```
 
 2. Run `govulncheck` from your project's root directory:
 
-    ```bash
-    govulncheck ./...
-    ```
+   ```bash
+   govulncheck ./...
+   ```
+
+For detailed information about govulncheck's capabilities, flags, and limitations, see the [official govulncheck documentation](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck).
 
 ## Configuration
 
-Optional inputs:
+### Go Environment
 
-  ```yaml
-  # Version of Go to use for govulncheck
-  go-version-input: # default: "stable"
+| Input                   | Description                                                      | Default    |
+|-------------------------|------------------------------------------------------------------|------------|
+| `setup-go`              | Setup Go via actions/setup-go                                    | `true`     |
+| `repo-checkout`         | Checkout the repository                                          | `true`     |
+| `go-version-input`      | Go version to use                                                | `"stable"` |
+| `go-version-file`       | Path to go.mod or go.work                                        | -          |
+| `check-latest`          | Always check for latest Go version                               | `true`     |
+| `cache`                 | Enable Go module caching                                         | `true`     |
+| `cache-dependency-path` | Path to dependency file for caching (e.g., go.sum for monorepos) | `""`       |
 
-  # Check for the latest Go version
-  check-latest: # default: true
+### Scan Options
 
-  # Specify whether Go caching is needed
-  cache: # default: true
+| Input           | Description                                                                                     | Default    |
+|-----------------|-------------------------------------------------------------------------------------------------|------------|
+| `go-package`    | Go package to scan (or binary path for binary mode)                                             | `"./..."`  |
+| `work-dir`      | Working directory                                                                               | `"."`      |
+| `scan-level`    | Scanning detail level: module, package, or symbol                                               | `"symbol"` |
+| `include-tests` | Include test files in vulnerability analysis (ignored in binary mode)                           | `false`    |
+| `build-tags`    | Comma-separated list of build tags                                                              | `""`       |
+| `db-url`        | Custom vulnerability database URL                                                               | `""`       |
+| `mode`          | Scan mode: source, binary, or extract                                                           | `"source"` |
+| `show`          | Show additional info: traces (full call stack), verbose (progress). Only valid for text format. | `""`       |
 
-  # Go package to scan with govulncheck
-  go-package: # default: "./..."
+### Output Options
 
-  # Directory in which to run govulncheck
-  work-dir: # default: "."
+| Input           | Description                               | Default  |
+|-----------------|-------------------------------------------|----------|
+| `output-format` | Output format: text, json, sarif, openvex | `"text"` |
+| `output-file`   | Output file path                          | `""`     |
 
-  # Checkout the repository
-  repo-checkout: # default: true
+### Scan Level
 
-  # Setup Go using actions/setup-go
-  setup-go: # default: true
+The `scan-level` input controls the detail level of the vulnerability analysis:
 
-  # Path to the go.mod or go.work file specifying the Go version
-  go-version-file: # no default
+| Level     | Description                                                                |
+|-----------|----------------------------------------------------------------------------|
+| `symbol`  | Most detailed - analyzes at function symbol level (default, most accurate) |
+| `package` | Analyzes at package level                                                  |
+| `module`  | Least detailed - analyzes at module level (fastest)                        |
 
-  # Output format ("text", "json", or "sarif")
-  output-format: # default: "text"
+### Scan Mode
 
-  # Output filepath
-  output-file: # default: ""
-  ```
+The `mode` input specifies how to analyze the code:
 
-Example GitHub workflow that uploads results to [CodeQL](https://docs.github.com/en/code-security/code-scanning/introduction-to-code-scanning/about-code-scanning-with-codeql):
+| Mode      | Description                                           |
+|-----------|-------------------------------------------------------|
+| `source`  | Analyze source code (default)                         |
+| `binary`  | Analyze a compiled binary (requires pre-built binary) |
+| `extract` | Extract information from binary for later analysis    |
+
+#### Binary Mode
+
+When using `mode: binary`, provide the path to a compiled binary instead of a package pattern:
 
 ```yaml
----
-name: Run govulncheck
-on:
-  pull_request:
-    branches: [main]
-  push:
-    branches: [main]
+- uses: nicholas-fedor/govulncheck-action@v1
+  with:
+    mode: binary
+    go-package: ./myapp
+```
+
+**Note:** The `-test` flag is not valid for binary mode and will be ignored if `mode: binary` is set.
+
+#### Show Output
+
+The `show` input enables additional output information:
+
+| Value     | Description                                   |
+|-----------|-----------------------------------------------|
+| `traces`  | Show full call stack for each vulnerability   |
+| `verbose` | Show progress messages and additional details |
+
+```yaml
+- uses: nicholas-fedor/govulncheck-action@v1
+  with:
+    show: traces
+    output-format: text
+```
+
+**Note:** The `-show` flag is only applicable for text output format.
+
+### Go Version Precedence
+
+The precedence for specifying the Go version via the inputs `go-version-input`, `go-version-file`, and `check-latest` is inherited from [actions/setup-go](https://github.com/actions/setup-go).
+
+### Output Formats
+
+| Format    | Description                                                                             |
+|-----------|-----------------------------------------------------------------------------------------|
+| `text`    | Human-readable text output (default)                                                    |
+| `json`    | JSON output with streaming support for large projects                                   |
+| `sarif`   | [SARIF](https://sarifweb.azurewebsites.net/) format for integration with security tools |
+| `openvex` | [OpenVEX](https://openvex.dev/) (Vulnerability EXchange) format                         |
+
+## Example Workflows
+
+### Basic
+
+```yaml
+name: Vulnerability Scanning
+on: [push, pull_request]
+
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nicholas-fedor/govulncheck-action@v1
+```
+
+### SARIF for Code Scanning
+
+```yaml
+name: Vulnerability Scanning
+on: [push, pull_request]
 
 permissions:
   contents: read
@@ -81,52 +182,93 @@ permissions:
   pull-requests: read
   security-events: write
 
-env:
-  GO_VERSION: 1.24.x
-  OUTPUT_FILE: results.sarif
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nicholas-fedor/govulncheck-action@v1
+        with:
+          output-format: sarif
+          output-file: results.sarif
 
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+```
+
+### JSON for Custom Processing
+
+```yaml
+name: Vulnerability Scanning
+on: [push, pull_request]
 
 jobs:
   govulncheck:
-    name: govulncheck
     runs-on: ubuntu-latest
-
-      - id: govulncheck
-        uses: nicholas-fedor/govulncheck-action@master
+    steps:
+      - uses: nicholas-fedor/govulncheck-action@v1
         with:
-          output-format: sarif
-          output-file: ${{ env.OUTPUT_FILE }}
-          go-version-input: ${{ env.GO_VERSION }}
-
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: ${{ env.OUTPUT_FILE }}
+          output-format: json
+          output-file: results.json
 ```
 
-The precedence for specifying the Go version via the inputs `go-version-input`, `go-version-file`, and `check-latest` is inherited from [actions/setup-go](https://github.com/actions/setup-go).
+### OpenVEX for Supply Chain Security
 
-The govulncheck-action follows the exit codes of govulncheck command.
-Specifying the output format 'json' or 'sarif' will return success even if there are some vulnerabilities detected. See [here](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck#hdr-Exit_codes)
-for more information.
+```yaml
+name: Vulnerability Scanning
+on: [push, pull_request]
 
-When a vulnerability is found with 'text' output format, an error will be displayed for that [GitHub job](https://docs.github.com/en/actions/using-jobs/using-jobs-in-a-workflow) with information about the vulnerability and how to fix it.
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: nicholas-fedor/govulncheck-action@v1
+        with:
+          output-format: openvex
+          output-file: results.vex
+```
 
-For example:
+### Binary Analysis
 
-![image](https://github.com/bkessler-go/prototype-repo/assets/107496148/932a2e5c-730e-4583-90f3-edab3ca06f60)
+```yaml
+name: Binary Vulnerability Scanning
+on: [push, pull_request]
 
-## Contributing
+jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build binary
+        run: go build -o myapp ./cmd/myapp
 
-Our canonical Git repository is located at <https://go.googlesource.com/govulncheck-action>.
-There is a mirror of the repository at <https://github.com/golang/govulncheck-action>.
-See <https://go.dev/doc/contribute.html> for details on how to contribute.
+      - uses: nicholas-fedor/govulncheck-action@v1
+        with:
+          mode: binary
+          go-package: ./myapp
+          output-format: sarif
+          output-file: results.sarif
 
-## Feedback
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif
+```
 
-If you want to report a bug or have a feature suggestion, please file an issue at <https://github.com/golang/go/issues>.
-Please, use the prefix `govulncheck-action:` in the issue title.
+## Exit Codes
+
+| Code | Description                                                            |
+|------|------------------------------------------------------------------------|
+| 0    | Success (no vulnerabilities found, or using json/sarif/openvex format) |
+| 1    | Vulnerabilities found (text output only)                               |
+| 2    | Error occurred                                                         |
+
+**Note:** When using `json`, `sarif`, or `openvex` output formats, govulncheck always exits successfully (code 0) regardless of vulnerabilities found. This allows CI/CD pipelines to upload results to external services without failing the build.
+
+Reference: <https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck#hdr-Exit_codes>
 
 ## License
 
-Unless otherwise noted, the Go source files are distributed under the BSD-style license found in the [LICENSE](LICENSE) file.
+See the [LICENSE](LICENSE) file.
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,12 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-action.json
 name: "golang-govulncheck-action"
 
 description: "Run govulncheck"
 
+# See https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck for govulncheck documentation
+
 inputs:
+  # Go environment
   go-version-input:
     description: "Version of Go to use for govulncheck"
     required: false
@@ -18,6 +22,26 @@ inputs:
     required: false
     default: "true"
 
+  cache-dependency-path:
+    description: "Used to specify the path to a dependency file (for monorepos) - go.sum"
+    required: false
+    default: ""
+
+  go-version-file:
+    description: "Path to the go.mod or go.work file."
+    required: false
+
+  setup-go:
+    description: "Setup Go using actions/setup-go"
+    required: false
+    default: "true"
+
+  repo-checkout:
+    description: "Checkout the repository"
+    required: false
+    default: "true"
+
+  # Scan options
   go-package:
     description: "Go Package to scan with govulncheck"
     required: false
@@ -28,20 +52,37 @@ inputs:
     required: false
     default: "."
 
-  repo-checkout:
-    description: "Checkout the repository"
+  scan-level:
+    description: "Scanning detail level: module, package, or symbol (default: symbol)"
     required: false
-    default: "true"
+    default: "symbol"
 
-  setup-go:
-    description: "Setup Go using actions/setup-go"
+  include-tests:
+    description: "Include test files in vulnerability analysis"
     required: false
-    default: "true"
+    default: "false"
 
-  go-version-file:
-    description: "Path to the go.mod or go.work file."
+  build-tags:
+    description: "Comma-separated list of build tags"
     required: false
+    default: ""
 
+  db-url:
+    description: "Custom vulnerability database URL (default: https://vuln.go.dev/)"
+    required: false
+    default: ""
+
+  mode:
+    description: "Scan mode: source, binary, or extract (default: source)"
+    required: false
+    default: "source"
+
+  show:
+    description: "Show additional information: traces (full call stack), verbose (progress details)"
+    required: false
+    default: ""
+
+  # Output options
   output-format:
     description: "The format of the output"
     required: false
@@ -55,55 +96,46 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - if: inputs.repo-checkout != 'false' # only explicit false prevents repo checkout
-      uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+    - if: inputs.repo-checkout != 'false'
+      name: Checkout repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
       with:
         fetch-depth: 0
         persist-credentials: false
 
-    # Default: use go-version when go-version-file is not specified
     - if: inputs.setup-go != 'false' && inputs.go-version-file == ''
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+      name: Setup Go
+      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
       with:
         go-version: ${{ inputs.go-version-input }}
         check-latest: ${{ inputs.check-latest }}
         cache: ${{ inputs.cache }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
 
-    # Override: use go-version-file if provided
-    # This avoids the warning from actions/setup-go when both are specified
     - if: inputs.setup-go != 'false' && inputs.go-version-file != ''
-      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+      name: Setup Go with go-version-file
+      uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5
       with:
         go-version-file: ${{ inputs.go-version-file }}
         check-latest: ${{ inputs.check-latest }}
         cache: ${{ inputs.cache }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
 
     - name: Install govulncheck
       run: go install golang.org/x/vuln/cmd/govulncheck@latest
       shell: bash
 
-    - if: inputs.output-file == ''
-      name: Run govulncheck
-      run: govulncheck -C "$INPUTS_WORK_DIR" -format "$INPUTS_OUTPUT_FORMAT" "$INPUTS_GO_PACKAGE"
+    - name: Run govulncheck
+      run: ${{ github.action_path }}/entrypoint.sh
       shell: bash
       env:
         INPUTS_WORK_DIR: ${{ inputs.work-dir }}
         INPUTS_OUTPUT_FORMAT: ${{ inputs.output-format }}
         INPUTS_GO_PACKAGE: ${{ inputs.go-package }}
-
-    - if: inputs.output-file != ''
-      name: Run govulncheck and save to file
-      run: govulncheck -C "$INPUTS_WORK_DIR" -format "$INPUTS_OUTPUT_FORMAT" "$INPUTS_GO_PACKAGE" > ${INPUTS_OUTPUT_FILE}
-      shell: bash
-      env:
-        INPUTS_WORK_DIR: ${{ inputs.work-dir }}
-        INPUTS_OUTPUT_FORMAT: ${{ inputs.output-format }}
-        INPUTS_GO_PACKAGE: ${{ inputs.go-package }}
-        INPUTS_OUTPUT_FILE: ${{ inputs.output-file }}
-
-    - if: inputs.output-format == 'sarif' && inputs.output-file != ''
-      name: Fix SARIF format
-      run: yq --inplace --output-format json '.runs |= map ({"results":[]} + .)' ${INPUTS_OUTPUT_FILE}
-      shell: bash
-      env:
+        INPUTS_SCAN_LEVEL: ${{ inputs.scan-level }}
+        INPUTS_INCLUDE_TESTS: ${{ inputs.include-tests }}
+        INPUTS_BUILD_TAGS: ${{ inputs.build-tags }}
+        INPUTS_DB_URL: ${{ inputs.db-url }}
+        INPUTS_MODE: ${{ inputs.mode }}
+        INPUTS_SHOW: ${{ inputs.show }}
         INPUTS_OUTPUT_FILE: ${{ inputs.output-file }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+# Main entrypoint for govulncheck-action
+# Orchestrates validation and execution
+
+set -euo pipefail
+
+# Load validation functions (relative to action directory)
+# shellcheck source=src/validate.sh
+source "${GITHUB_ACTION_PATH}/src/validate.sh"
+
+# Load argument builder (relative to action directory)
+# shellcheck source=src/build-args.sh
+source "${GITHUB_ACTION_PATH}/src/build-args.sh"
+
+# Get input values from environment
+INPUTS_WORK_DIR="${INPUTS_WORK_DIR:-.}"
+INPUTS_OUTPUT_FORMAT="${INPUTS_OUTPUT_FORMAT:-text}"
+INPUTS_GO_PACKAGE="${INPUTS_GO_PACKAGE:-./...}"
+INPUTS_SCAN_LEVEL="${INPUTS_SCAN_LEVEL:-symbol}"
+INPUTS_INCLUDE_TESTS="${INPUTS_INCLUDE_TESTS:-false}"
+INPUTS_BUILD_TAGS="${INPUTS_BUILD_TAGS:-}"
+INPUTS_DB_URL="${INPUTS_DB_URL:-}"
+INPUTS_MODE="${INPUTS_MODE:-source}"
+INPUTS_SHOW="${INPUTS_SHOW:-}"
+INPUTS_OUTPUT_FILE="${INPUTS_OUTPUT_FILE:-}"
+
+# Get workspace path for validation
+WORKSPACE="${GITHUB_WORKSPACE:-.}"
+
+echo "Running validations..."
+run_all_validations \
+    "$INPUTS_OUTPUT_FORMAT" \
+    "$INPUTS_SCAN_LEVEL" \
+    "$INPUTS_MODE" \
+    "$INPUTS_SHOW" \
+    "$INPUTS_INCLUDE_TESTS" \
+    "$INPUTS_GO_PACKAGE" \
+    "$INPUTS_WORK_DIR" \
+    "$INPUTS_OUTPUT_FILE" \
+    "$WORKSPACE"
+
+echo "Building govulncheck arguments..."
+IFS=' ' read -ra ARGS <<< "$(build_args \
+    "$INPUTS_WORK_DIR" \
+    "$INPUTS_OUTPUT_FORMAT" \
+    "$INPUTS_GO_PACKAGE" \
+    "$INPUTS_SCAN_LEVEL" \
+    "$INPUTS_INCLUDE_TESTS" \
+    "$INPUTS_BUILD_TAGS" \
+    "$INPUTS_DB_URL" \
+    "$INPUTS_MODE" \
+    "$INPUTS_SHOW")"
+
+echo "Running govulncheck with arguments: ${ARGS[*]}"
+
+# Run govulncheck with or without output file
+if [[ -n "$INPUTS_OUTPUT_FILE" ]]; then
+    govulncheck "${ARGS[@]}" "$INPUTS_GO_PACKAGE" > "$INPUTS_OUTPUT_FILE"
+
+    # Apply SARIF workaround if needed (https://github.com/golang/go/issues/75890)
+    if [[ "$INPUTS_OUTPUT_FORMAT" == "sarif" ]]; then
+        echo "Applying SARIF duplicate tags fix..."
+        # shellcheck source=src/fix-sarif.sh
+        source "${GITHUB_ACTION_PATH}/src/fix-sarif.sh"
+        fix_sarif "$INPUTS_OUTPUT_FILE"
+    fi
+else
+    govulncheck "${ARGS[@]}" "$INPUTS_GO_PACKAGE"
+fi
+
+echo "govulncheck completed successfully"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,7 @@ run_all_validations \
     "$WORKSPACE"
 
 echo "Building govulncheck arguments..."
-IFS=' ' read -ra ARGS <<< "$(build_args \
+mapfile -t -d '' ARGS < <(build_args \
     "$INPUTS_WORK_DIR" \
     "$INPUTS_OUTPUT_FORMAT" \
     "$INPUTS_GO_PACKAGE" \
@@ -49,13 +49,14 @@ IFS=' ' read -ra ARGS <<< "$(build_args \
     "$INPUTS_BUILD_TAGS" \
     "$INPUTS_DB_URL" \
     "$INPUTS_MODE" \
-    "$INPUTS_SHOW")"
+    "$INPUTS_SHOW"
+)
 
 echo "Running govulncheck with arguments: ${ARGS[*]}"
 
 # Run govulncheck with or without output file
 if [[ -n "$INPUTS_OUTPUT_FILE" ]]; then
-    govulncheck "${ARGS[@]}" "$INPUTS_GO_PACKAGE" > "$INPUTS_OUTPUT_FILE"
+    govulncheck "${ARGS[@]}" > "$INPUTS_OUTPUT_FILE"
 
     # Apply SARIF workaround if needed (https://github.com/golang/go/issues/75890)
     if [[ "$INPUTS_OUTPUT_FORMAT" == "sarif" ]]; then
@@ -65,7 +66,7 @@ if [[ -n "$INPUTS_OUTPUT_FILE" ]]; then
         fix_sarif "$INPUTS_OUTPUT_FILE"
     fi
 else
-    govulncheck "${ARGS[@]}" "$INPUTS_GO_PACKAGE"
+    govulncheck "${ARGS[@]}"
 fi
 
 echo "govulncheck completed successfully"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,11 +5,11 @@
 set -euo pipefail
 
 # Load validation functions (relative to action directory)
-# shellcheck source=src/validate.sh
+# shellcheck disable=SC1091
 source "${GITHUB_ACTION_PATH}/src/validate.sh"
 
 # Load argument builder (relative to action directory)
-# shellcheck source=src/build-args.sh
+# shellcheck disable=SC1091
 source "${GITHUB_ACTION_PATH}/src/build-args.sh"
 
 # Get input values from environment
@@ -60,7 +60,7 @@ if [[ -n "$INPUTS_OUTPUT_FILE" ]]; then
     # Apply SARIF workaround if needed (https://github.com/golang/go/issues/75890)
     if [[ "$INPUTS_OUTPUT_FORMAT" == "sarif" ]]; then
         echo "Applying SARIF duplicate tags fix..."
-        # shellcheck source=src/fix-sarif.sh
+        # shellcheck disable=SC1091
         source "${GITHUB_ACTION_PATH}/src/fix-sarif.sh"
         fix_sarif "$INPUTS_OUTPUT_FILE"
     fi

--- a/src/build-args.sh
+++ b/src/build-args.sh
@@ -55,8 +55,8 @@ build_args() {
     # Add the package to scan
     args+=("$go_package")
 
-    # Output the arguments
-    printf '%s\n' "${args[*]}"
+    # Output the arguments with NUL delimiter
+    printf '%s\0' "${args[@]}"
 }
 
 # If sourced with test mode, run tests
@@ -65,7 +65,7 @@ if [[ "${BATS_TEST:-false}" == "true" ]]; then
 fi
 
 # If run directly, build and print arguments
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+if [[ -n "${BASH_SOURCE[0]:-}" && "${BASH_SOURCE[0]}" == "${0}" ]]; then
     build_args \
         "${INPUTS_WORK_DIR:-.}" \
         "${INPUTS_OUTPUT_FORMAT:-text}" \

--- a/src/build-args.sh
+++ b/src/build-args.sh
@@ -2,6 +2,9 @@
 # Build govulncheck arguments based on inputs
 # Returns the arguments as a space-separated string
 
+# shellcheck disable=SC2317
+# Command appears unreachable - but return is valid when sourced for BATS tests
+
 set -euo pipefail
 
 build_args() {

--- a/src/build-args.sh
+++ b/src/build-args.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Build govulncheck arguments based on inputs
+# Returns the arguments as a space-separated string
+
+set -euo pipefail
+
+build_args() {
+    local work_dir="$1"
+    local output_format="$2"
+    local go_package="$3"
+    local scan_level="$4"
+    local include_tests="$5"
+    local build_tags="$6"
+    local db_url="$7"
+    local mode="$8"
+    local show="$9"
+
+    local args=("-C" "$work_dir" "-format" "$output_format")
+
+    # Only add -scan-level if not default (symbol)
+    if [[ -n "$scan_level" && "$scan_level" != "symbol" ]]; then
+        args+=(-scan-level "$scan_level")
+    fi
+
+    # Only add -test if explicitly enabled and in source mode
+    # Note: -test is only valid for source mode
+    if [[ "$include_tests" == "true" && "$mode" == "source" ]]; then
+        args+=(-test)
+    fi
+
+    # Only add -tags if provided
+    if [[ -n "$build_tags" ]]; then
+        args+=(-tags "$build_tags")
+    fi
+
+    # Only add -db if custom DB URL provided
+    if [[ -n "$db_url" ]]; then
+        args+=(-db "$db_url")
+    fi
+
+    # Only add -mode if not default (source)
+    if [[ -n "$mode" && "$mode" != "source" ]]; then
+        args+=(-mode "$mode")
+    fi
+
+    # Only add -show if provided and output format is text
+    # Note: -show is only valid for text output format
+    if [[ -n "$show" && "$output_format" == "text" ]]; then
+        args+=(-show "$show")
+    fi
+
+    # Add the package to scan
+    args+=("$go_package")
+
+    # Output the arguments
+    printf '%s\n' "${args[*]}"
+}
+
+# If sourced with test mode, run tests
+if [[ "${BATS_TEST:-false}" == "true" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+
+# If run directly, build and print arguments
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    build_args \
+        "${INPUTS_WORK_DIR:-.}" \
+        "${INPUTS_OUTPUT_FORMAT:-text}" \
+        "${INPUTS_GO_PACKAGE:-./...}" \
+        "${INPUTS_SCAN_LEVEL:-symbol}" \
+        "${INPUTS_INCLUDE_TESTS:-false}" \
+        "${INPUTS_BUILD_TAGS:-}" \
+        "${INPUTS_DB_URL:-}" \
+        "${INPUTS_MODE:-source}" \
+        "${INPUTS_SHOW:-}"
+fi

--- a/src/fix-sarif.sh
+++ b/src/fix-sarif.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+# SARIF post-processing to fix duplicate CVE tags
+# Workaround for https://github.com/golang/go/issues/75890
+
+set -euo pipefail
+
+fix_sarif() {
+    local output_file="$1"
+
+    if [[ -z "$output_file" ]]; then
+        echo "Error: INPUTS_OUTPUT_FILE is required"
+        return 1
+    fi
+
+    if [[ ! -f "$output_file" ]]; then
+        echo "Error: Output file does not exist: $output_file"
+        return 1
+    fi
+
+    jq '.runs[].tool.driver.rules |= map(.properties.tags |= (if . != null then unique else . end))' "$output_file" > "${output_file}.tmp" && mv "${output_file}.tmp" "$output_file"
+
+    echo "SARIF duplicate tags fixed"
+}
+
+# If sourced with test mode, run tests
+if [[ "${BATS_TEST:-false}" == "true" ]]; then
+    return 0 2>/dev/null || exit 0
+fi
+
+# If run directly, execute fix
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    INPUTS_OUTPUT_FILE="${INPUTS_OUTPUT_FILE:-}"
+    fix_sarif "$INPUTS_OUTPUT_FILE"
+fi

--- a/src/fix-sarif.sh
+++ b/src/fix-sarif.sh
@@ -25,7 +25,7 @@ fix_sarif() {
 
     trap 'rm -f "$temp_file"' EXIT
 
-    jq '.runs[].tool.driver.rules |= map(.properties.tags |= (if . != null then unique else . end))' "$output_file" > "$temp_file" && mv "$temp_file" "$output_file"
+    jq '.runs[].tool.driver.rules |= map(select(.properties != null and .properties.tags != null) | .properties.tags |= unique)' "$output_file" > "$temp_file" && mv "$temp_file" "$output_file"
 
     trap - EXIT
 

--- a/src/fix-sarif.sh
+++ b/src/fix-sarif.sh
@@ -20,7 +20,14 @@ fix_sarif() {
         return 1
     fi
 
-    jq '.runs[].tool.driver.rules |= map(.properties.tags |= (if . != null then unique else . end))' "$output_file" > "${output_file}.tmp" && mv "${output_file}.tmp" "$output_file"
+    local temp_file
+    temp_file=$(mktemp)
+
+    trap 'rm -f "$temp_file"' EXIT
+
+    jq '.runs[].tool.driver.rules |= map(.properties.tags |= (if . != null then unique else . end))' "$output_file" > "$temp_file" && mv "$temp_file" "$output_file"
+
+    trap - EXIT
 
     echo "SARIF duplicate tags fixed"
 }

--- a/src/fix-sarif.sh
+++ b/src/fix-sarif.sh
@@ -2,6 +2,9 @@
 # SARIF post-processing to fix duplicate CVE tags
 # Workaround for https://github.com/golang/go/issues/75890
 
+# shellcheck disable=SC2317
+# Command appears unreachable - but return is valid when sourced for BATS tests
+
 set -euo pipefail
 
 fix_sarif() {

--- a/src/validate.sh
+++ b/src/validate.sh
@@ -1,0 +1,145 @@
+#!/bin/bash
+# Validation functions for govulncheck-action
+# These functions are pure and testable
+
+set -euo pipefail
+
+validate_output_format() {
+    local value="$1"
+    case "$value" in
+        text|json|sarif|openvex) return 0 ;;
+        *) echo "Error: Invalid output-format '$value'. Valid values: text, json, sarif, openvex" && return 1 ;;
+    esac
+}
+
+validate_scan_level() {
+    local value="$1"
+    case "$value" in
+        module|package|symbol) return 0 ;;
+        *) echo "Error: Invalid scan-level '$value'. Valid values: module, package, symbol" && return 1 ;;
+    esac
+}
+
+validate_mode() {
+    local value="$1"
+    case "$value" in
+        source|binary|extract) return 0 ;;
+        *) echo "Error: Invalid mode '$value'. Valid values: source, binary, extract" && return 1 ;;
+    esac
+}
+
+validate_show() {
+    local value="$1"
+    case "$value" in
+        traces|verbose) return 0 ;;
+        *) echo "Error: Invalid show '$value'. Valid values: traces, verbose" && return 1 ;;
+    esac
+}
+
+validate_include_tests() {
+    local value="$1"
+    if [[ -n "$value" && "$value" != "true" && "$value" != "false" ]]; then
+        echo "Error: Invalid include-tests '$value'. Valid values: true, false"
+        return 1
+    fi
+    return 0
+}
+
+validate_go_package() {
+    local value="$1"
+    if [[ -z "$value" ]]; then
+        echo "Error: go-package cannot be empty"
+        return 1
+    fi
+    return 0
+}
+
+# Security: Validate output-file path is within workspace
+validate_output_file_path() {
+    local output_file="$1"
+    local workspace="${2:-.}"
+
+    if [[ -z "$output_file" ]]; then
+        return 0
+    fi
+
+    local output_path
+    output_path="$(realpath -m "$workspace/$output_file" 2>/dev/null || echo "$workspace/$output_file")"
+    local workspace_path
+    workspace_path="$(realpath -m "$workspace" 2>/dev/null || echo "$workspace")"
+
+    if [[ "$output_path" != "$workspace_path"* ]]; then
+        echo "Error: output-file path must be within workspace"
+        return 1
+    fi
+    return 0
+}
+
+# Security: Validate work-dir path is within workspace
+validate_work_dir_path() {
+    local work_dir="$1"
+    local workspace="${2:-.}"
+
+    if [[ -z "$work_dir" || "$work_dir" == "." ]]; then
+        return 0
+    fi
+
+    local work_dir_path
+    work_dir_path="$(realpath -m "$workspace/$work_dir" 2>/dev/null || echo "$workspace/$work_dir")"
+    local workspace_path
+    workspace_path="$(realpath -m "$workspace" 2>/dev/null || echo "$workspace")"
+
+    if [[ "$work_dir_path" != "$workspace_path"* ]]; then
+        echo "Error: work-dir path must be within workspace"
+        return 1
+    fi
+    return 0
+}
+
+run_all_validations() {
+    local output_format="${1:-}"
+    local scan_level="${2:-}"
+    local mode="${3:-}"
+    local show="${4:-}"
+    local include_tests="${5:-}"
+    local go_package="${6:-}"
+    local work_dir="${7:-.}"
+    local output_file="${8:-}"
+    local workspace="${9:-.}"
+
+    # Validate output-format
+    if [[ -n "$output_format" ]]; then
+        validate_output_format "$output_format" || return 1
+    fi
+
+    # Validate scan-level
+    if [[ -n "$scan_level" ]]; then
+        validate_scan_level "$scan_level" || return 1
+    fi
+
+    # Validate mode
+    if [[ -n "$mode" ]]; then
+        validate_mode "$mode" || return 1
+    fi
+
+    # Validate show
+    if [[ -n "$show" ]]; then
+        validate_show "$show" || return 1
+    fi
+
+    # Validate include-tests
+    if [[ -n "$include_tests" ]]; then
+        validate_include_tests "$include_tests" || return 1
+    fi
+
+    # Validate go-package (required, cannot be empty)
+    validate_go_package "$go_package" || return 1
+
+    # Security: Validate work-dir path
+    validate_work_dir_path "$work_dir" "$workspace" || return 1
+
+    # Security: Validate output-file path
+    validate_output_file_path "$output_file" "$workspace" || return 1
+
+    return 0
+}

--- a/src/validate.sh
+++ b/src/validate.sh
@@ -108,8 +108,9 @@ validate_work_dir_path() {
     work_dir_path="$(realpath -m "$workspace/$work_dir" 2>/dev/null || echo "$workspace/$work_dir")"
     local workspace_path
     workspace_path="$(realpath -m "$workspace" 2>/dev/null || echo "$workspace")"
+    workspace_path="${workspace_path%/}"
 
-    if [[ "$work_dir_path" != "${workspace_path%/}/"* ]]; then
+    if [[ "$work_dir_path" != "${workspace_path}"/* && "$work_dir_path" != "${workspace_path}" ]]; then
         echo "Error: work-dir path must be within workspace"
         return 1
     fi

--- a/src/validate.sh
+++ b/src/validate.sh
@@ -63,12 +63,22 @@ validate_output_file_path() {
         return 0
     fi
 
+    if [[ "$output_file" = /* ]]; then
+        echo "Error: output-file path must be a relative path"
+        return 1
+    fi
+
+    if [[ "$output_file" == *".."* || "$output_file" == *"%2e"* || "$output_file" == *"%2E"* ]]; then
+        echo "Error: output-file path must be within workspace"
+        return 1
+    fi
+
     local output_path
     output_path="$(realpath -m "$workspace/$output_file" 2>/dev/null || echo "$workspace/$output_file")"
     local workspace_path
     workspace_path="$(realpath -m "$workspace" 2>/dev/null || echo "$workspace")"
 
-    if [[ "$output_path" != "$workspace_path"* ]]; then
+    if [[ "$output_path" != "${workspace_path%/}/"* ]]; then
         echo "Error: output-file path must be within workspace"
         return 1
     fi
@@ -84,12 +94,22 @@ validate_work_dir_path() {
         return 0
     fi
 
+    if [[ "$work_dir" = /* ]]; then
+        echo "Error: work-dir path must be a relative path"
+        return 1
+    fi
+
+    if [[ "$work_dir" == *".."* || "$work_dir" == *"%2e"* || "$work_dir" == *"%2E"* ]]; then
+        echo "Error: work-dir path must be within workspace"
+        return 1
+    fi
+
     local work_dir_path
     work_dir_path="$(realpath -m "$workspace/$work_dir" 2>/dev/null || echo "$workspace/$work_dir")"
     local workspace_path
     workspace_path="$(realpath -m "$workspace" 2>/dev/null || echo "$workspace")"
 
-    if [[ "$work_dir_path" != "$workspace_path"* ]]; then
+    if [[ "$work_dir_path" != "${workspace_path%/}/"* ]]; then
         echo "Error: work-dir path must be within workspace"
         return 1
     fi

--- a/tests/build_args_test.sh
+++ b/tests/build_args_test.sh
@@ -3,76 +3,91 @@
 load ../src/build-args.sh
 
 @test "build_args returns basic arguments" {
-    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
-    [[ "$result" == *"-C"*"."*" -format"*"text"*"./..."* ]]
+    mapfile -t -d '' result < <(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
+    result_str="${result[*]}"
+    [[ "$result_str" == *"-C"*". "*"-format"*text*"./..."* ]]
 }
 
 @test "build_args includes scan-level when not default" {
-    result=$(build_args "." "text" "./..." "module" "false" "" "" "source" "")
-    [[ "$result" == *"-scan-level"*"module"* ]]
+    mapfile -t -d '' result < <(build_args "." "text" "./..." "module" "false" "" "" "source" "")
+    result_str="${result[*]}"
+    [[ "$result_str" == *"-scan-level"*module* ]]
 }
 
 @test "build_args excludes scan-level when default" {
-    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
-    [[ "$result" != *"-scan-level"* ]]
+    mapfile -t -d '' result < <(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
+    result_str="${result[*]}"
+    [[ "$result_str" != *"-scan-level"* ]]
 }
 
 @test "build_args includes -test when enabled in source mode" {
-    result=$(build_args "." "text" "./..." "symbol" "true" "" "" "source" "")
-    [[ "$result" == *"-test"* ]]
+    mapfile -t -d '' result < <(build_args "." "text" "./..." "symbol" "true" "" "" "source" "")
+    result_str="${result[*]}"
+    [[ "$result_str" == *"-test"* ]]
 }
 
 @test "build_args excludes -test when disabled" {
-    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
-    [[ "$result" != *"-test"* ]]
+    mapfile -t -d '' result < <(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
+    result_str="${result[*]}"
+    [[ "$result_str" != *"-test"* ]]
 }
 
 @test "build_args excludes -test in binary mode" {
-    result=$(build_args "." "text" "./..." "symbol" "true" "" "" "binary" "")
-    [[ "$result" != *"-test"* ]]
+    mapfile -t -d '' result < <(build_args "." "text" "./..." "symbol" "true" "" "" "binary" "")
+    result_str="${result[*]}"
+    [[ "$result_str" != *"-test"* ]]
 }
 
 @test "build_args includes -tags when provided" {
-    result=$(build_args "." "text" "./..." "symbol" "false" "tag1,tag2" "" "source" "")
-    [[ "$result" == *"-tags"*"tag1,tag2"* ]]
+    mapfile -t -d '' result < <(build_args "." "text" "./..." "symbol" "false" "tag1,tag2" "" "source" "")
+    result_str="${result[*]}"
+    [[ "$result_str" == *"-tags"*tag1,tag2* ]]
 }
 
 @test "build_args excludes -tags when empty" {
-    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
-    [[ "$result" != *"-tags"* ]]
+    mapfile -t -d '' result < <(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
+    result_str="${result[*]}"
+    [[ "$result_str" != *"-tags"* ]]
 }
 
 @test "build_args includes -db when provided" {
-    result=$(build_args "." "text" "./..." "symbol" "false" "" "https://custom.db" "source" "")
-    [[ "$result" == *"-db"*"https://custom.db"* ]]
+    mapfile -t -d '' result < <(build_args "." "text" "./..." "symbol" "false" "" "https://custom.db" "source" "")
+    result_str="${result[*]}"
+    [[ "$result_str" == *"-db"*https://custom.db* ]]
 }
 
 @test "build_args excludes -db when empty" {
-    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
-    [[ "$result" != *"-db"* ]]
+    mapfile -t -d '' result < <(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
+    result_str="${result[*]}"
+    [[ "$result_str" != *"-db"* ]]
 }
 
 @test "build_args includes -mode when not default" {
-    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "binary" "")
-    [[ "$result" == *"-mode"*"binary"* ]]
+    mapfile -t -d '' result < <(build_args "." "text" "./..." "symbol" "false" "" "" "binary" "")
+    result_str="${result[*]}"
+    [[ "$result_str" == *"-mode"*binary* ]]
 }
 
 @test "build_args excludes -mode when default" {
-    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
-    [[ "$result" != *"-mode"* ]]
+    mapfile -t -d '' result < <(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
+    result_str="${result[*]}"
+    [[ "$result_str" != *"-mode"* ]]
 }
 
 @test "build_args includes -show when provided with text format" {
-    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "traces")
-    [[ "$result" == *"-show"*"traces"* ]]
+    mapfile -t -d '' result < <(build_args "." "text" "./..." "symbol" "false" "" "" "source" "traces")
+    result_str="${result[*]}"
+    [[ "$result_str" == *"-show"*traces* ]]
 }
 
 @test "build_args excludes -show when empty" {
-    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
-    [[ "$result" != *"-show"* ]]
+    mapfile -t -d '' result < <(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
+    result_str="${result[*]}"
+    [[ "$result_str" != *"-show"* ]]
 }
 
 @test "build_args excludes -show with non-text format" {
-    result=$(build_args "." "json" "./..." "symbol" "false" "" "" "source" "verbose")
-    [[ "$result" != *"-show"* ]]
+    mapfile -t -d '' result < <(build_args "." "json" "./..." "symbol" "false" "" "" "source" "verbose")
+    result_str="${result[*]}"
+    [[ "$result_str" != *"-show"* ]]
 }

--- a/tests/build_args_test.sh
+++ b/tests/build_args_test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+
+load ../src/build-args.sh
+
+@test "build_args returns basic arguments" {
+    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
+    [[ "$result" == *"-C"*"."*" -format"*"text"*"./..."* ]]
+}
+
+@test "build_args includes scan-level when not default" {
+    result=$(build_args "." "text" "./..." "module" "false" "" "" "source" "")
+    [[ "$result" == *"-scan-level"*"module"* ]]
+}
+
+@test "build_args excludes scan-level when default" {
+    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
+    [[ "$result" != *"-scan-level"* ]]
+}
+
+@test "build_args includes -test when enabled in source mode" {
+    result=$(build_args "." "text" "./..." "symbol" "true" "" "" "source" "")
+    [[ "$result" == *"-test"* ]]
+}
+
+@test "build_args excludes -test when disabled" {
+    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
+    [[ "$result" != *"-test"* ]]
+}
+
+@test "build_args excludes -test in binary mode" {
+    result=$(build_args "." "text" "./..." "symbol" "true" "" "" "binary" "")
+    [[ "$result" != *"-test"* ]]
+}
+
+@test "build_args includes -tags when provided" {
+    result=$(build_args "." "text" "./..." "symbol" "false" "tag1,tag2" "" "source" "")
+    [[ "$result" == *"-tags"*"tag1,tag2"* ]]
+}
+
+@test "build_args excludes -tags when empty" {
+    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
+    [[ "$result" != *"-tags"* ]]
+}
+
+@test "build_args includes -db when provided" {
+    result=$(build_args "." "text" "./..." "symbol" "false" "" "https://custom.db" "source" "")
+    [[ "$result" == *"-db"*"https://custom.db"* ]]
+}
+
+@test "build_args excludes -db when empty" {
+    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
+    [[ "$result" != *"-db"* ]]
+}
+
+@test "build_args includes -mode when not default" {
+    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "binary" "")
+    [[ "$result" == *"-mode"*"binary"* ]]
+}
+
+@test "build_args excludes -mode when default" {
+    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
+    [[ "$result" != *"-mode"* ]]
+}
+
+@test "build_args includes -show when provided with text format" {
+    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "traces")
+    [[ "$result" == *"-show"*"traces"* ]]
+}
+
+@test "build_args excludes -show when empty" {
+    result=$(build_args "." "text" "./..." "symbol" "false" "" "" "source" "")
+    [[ "$result" != *"-show"* ]]
+}
+
+@test "build_args excludes -show with non-text format" {
+    result=$(build_args "." "json" "./..." "symbol" "false" "" "" "source" "verbose")
+    [[ "$result" != *"-show"* ]]
+}

--- a/tests/fix_sarif_test.sh
+++ b/tests/fix_sarif_test.sh
@@ -46,8 +46,8 @@ EOF
     run fix_sarif "$temp_file"
     [[ "$status" -eq 0 ]]
 
-    tag_count=$(jq -r '.runs[0].tool.driver.rules[0].properties.tags | length' "$temp_file")
-    [[ "$tag_count" -eq 1 ]]
+    tags=$(jq -c '.runs[0].tool.driver.rules[0].properties.tags' "$temp_file")
+    [[ "$tags" == '["CVE-2024-0001"]' ]]
 
     rm -f "$temp_file"
 }
@@ -102,8 +102,8 @@ EOF
     run fix_sarif "$temp_file"
     [[ "$status" -eq 0 ]]
 
-    tag_count=$(jq -r '.runs[0].tool.driver.rules[0].properties.tags | length' "$temp_file")
-    [[ "$tag_count" -eq 1 ]]
+    tags=$(jq -c '.runs[0].tool.driver.rules[0].properties.tags' "$temp_file")
+    [[ "$tags" == '["CVE-2024-0001"]' ]]
 
     rm -f "$temp_file"
 }
@@ -131,6 +131,9 @@ EOF
 
     run fix_sarif "$temp_file"
     [[ "$status" -eq 0 ]]
+
+    has_properties=$(jq -r '.runs[0].tool.driver.rules[0] | has("properties")' "$temp_file")
+    [[ "$has_properties" == "false" ]]
 
     rm -f "$temp_file"
 }

--- a/tests/fix_sarif_test.sh
+++ b/tests/fix_sarif_test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bats
+bats_require_minimum_version 1.5.0
+
+# Test SARIF fix functionality
+load ../src/fix-sarif.sh
+
+@test "fix_sarif function exists" {
+    type -t fix_sarif | grep -q function
+}
+
+@test "fix_sarif handles missing file path" {
+    run fix_sarif ""
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"Error: INPUTS_OUTPUT_FILE is required"* ]]
+}
+
+@test "fix_sarif handles non-existent file" {
+    run fix_sarif "/nonexistent/file.sarif"
+    [[ "$status" -eq 1 ]]
+    [[ "$output" == *"does not exist"* ]]
+}
+
+@test "fix_sarif removes duplicate tags" {
+    local temp_file
+    temp_file=$(mktemp)
+    cat > "$temp_file" << 'EOF'
+{
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "rules": [
+            {
+              "id": "GO-2024-0001",
+              "properties": {
+                "tags": ["CVE-2024-0001", "CVE-2024-0001"]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+EOF
+
+    run fix_sarif "$temp_file"
+    [[ "$status" -eq 0 ]]
+
+    tag_count=$(jq -r '.runs[0].tool.driver.rules[0].properties.tags | length' "$temp_file")
+    [[ "$tag_count" -eq 1 ]]
+
+    rm -f "$temp_file"
+}
+
+@test "fix_sarif preserves non-duplicate tags" {
+    local temp_file
+    temp_file=$(mktemp)
+    cat > "$temp_file" << 'EOF'
+{
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "rules": [
+            {
+              "id": "GO-2024-0001",
+              "properties": {
+                "tags": ["CVE-2024-0001"]
+              }
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+EOF
+
+    run fix_sarif "$temp_file"
+    [[ "$status" -eq 0 ]]
+
+    tag_count=$(jq -r '.runs[0].tool.driver.rules[0].properties.tags | length' "$temp_file")
+    [[ "$tag_count" -eq 1 ]]
+
+    rm -f "$temp_file"
+}
+
+@test "fix_sarif handles rules without properties" {
+    local temp_file
+    temp_file=$(mktemp)
+    cat > "$temp_file" << 'EOF'
+{
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "rules": [
+            {
+              "id": "GO-2024-0001"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}
+EOF
+
+    run fix_sarif "$temp_file"
+    [[ "$status" -eq 0 ]]
+
+    rm -f "$temp_file"
+}

--- a/tests/fix_sarif_test.sh
+++ b/tests/fix_sarif_test.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bats
-bats_require_minimum_version 1.5.0
 
 # Test SARIF fix functionality
 load ../src/fix-sarif.sh

--- a/tests/fix_sarif_test.sh
+++ b/tests/fix_sarif_test.sh
@@ -52,6 +52,29 @@ EOF
     rm -f "$temp_file"
 }
 
+@test "fix_sarif handles empty rules array" {
+    local temp_file
+    temp_file=$(mktemp)
+    cat > "$temp_file" << 'EOF'
+{
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "rules": []
+        }
+      }
+    }
+  ]
+}
+EOF
+
+    run fix_sarif "$temp_file"
+    [[ "$status" -eq 0 ]]
+
+    rm -f "$temp_file"
+}
+
 @test "fix_sarif preserves non-duplicate tags" {
     local temp_file
     temp_file=$(mktemp)

--- a/tests/validate_test.sh
+++ b/tests/validate_test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bats
+
+load ../src/validate.sh
+
+@test "validate_output_format accepts text" {
+    run validate_output_format "text"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_output_format accepts json" {
+    run validate_output_format "json"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_output_format accepts sarif" {
+    run validate_output_format "sarif"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_output_format accepts openvex" {
+    run validate_output_format "openvex"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_output_format rejects invalid" {
+    run validate_output_format "invalid"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: Invalid output-format"* ]]
+}
+
+@test "validate_scan_level accepts symbol" {
+    run validate_scan_level "symbol"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_scan_level accepts package" {
+    run validate_scan_level "package"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_scan_level accepts module" {
+    run validate_scan_level "module"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_scan_level rejects invalid" {
+    run validate_scan_level "invalid"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: Invalid scan-level"* ]]
+}
+
+@test "validate_mode accepts source" {
+    run validate_mode "source"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_mode accepts binary" {
+    run validate_mode "binary"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_mode accepts extract" {
+    run validate_mode "extract"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_mode rejects invalid" {
+    run validate_mode "invalid"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: Invalid mode"* ]]
+}
+
+@test "validate_show accepts traces" {
+    run validate_show "traces"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_show accepts verbose" {
+    run validate_show "verbose"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_show rejects invalid" {
+    run validate_show "invalid"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: Invalid show"* ]]
+}
+
+@test "validate_include_tests accepts true" {
+    run validate_include_tests "true"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_include_tests accepts false" {
+    run validate_include_tests "false"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_include_tests rejects empty string" {
+    run validate_include_tests ""
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_include_tests rejects invalid" {
+    run validate_include_tests "maybe"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: Invalid include-tests"* ]]
+}
+
+@test "validate_go_package accepts ./..." {
+    run validate_go_package "./..."
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_go_package accepts ./cmd/app" {
+    run validate_go_package "./cmd/app"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_go_package rejects empty" {
+    run validate_go_package ""
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: go-package cannot be empty"* ]]
+}
+
+@test "run_all_validations passes with valid inputs" {
+    run run_all_validations "json" "symbol" "source" "" "false" "./..." "." "" "/workspace"
+    [ "$status" -eq 0 ]
+}
+
+@test "run_all_validations fails with invalid output-format" {
+    run run_all_validations "invalid" "symbol" "source" "" "false" "./..." "." "" "/workspace"
+    [ "$status" -eq 1 ]
+}
+
+@test "run_all_validations fails with invalid scan-level" {
+    run run_all_validations "text" "invalid" "source" "" "false" "./..." "." "" "/workspace"
+    [ "$status" -eq 1 ]
+}
+
+@test "run_all_validations fails with invalid mode" {
+    run run_all_validations "text" "symbol" "invalid" "" "false" "./..." "." "" "/workspace"
+    [ "$status" -eq 1 ]
+}
+
+@test "run_all_validations fails with invalid show" {
+    run run_all_validations "text" "symbol" "source" "invalid" "false" "./..." "." "" "/workspace"
+    [ "$status" -eq 1 ]
+}
+
+@test "run_all_validations fails with invalid include-tests" {
+    run run_all_validations "text" "symbol" "source" "" "maybe" "./..." "." "" "/workspace"
+    [ "$status" -eq 1 ]
+}
+
+@test "run_all_validations fails with empty go-package" {
+    run run_all_validations "text" "symbol" "source" "" "false" "" "." "" "."
+    [ "$status" -eq 1 ]
+}
+
+@test "validate_output_file_path allows valid path" {
+    run validate_output_file_path "results.json" "/workspace"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_output_file_path allows empty path" {
+    run validate_output_file_path "" "/workspace"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_output_file_path rejects path traversal" {
+    run validate_output_file_path "../etc/passwd" "/workspace"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: output-file path must be within workspace"* ]]
+}
+
+@test "validate_work_dir_path allows valid path" {
+    run validate_work_dir_path "src" "/workspace"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_work_dir_path allows dot" {
+    run validate_work_dir_path "." "/workspace"
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_work_dir_path rejects path traversal" {
+    run validate_work_dir_path "../etc" "/workspace"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: work-dir path must be within workspace"* ]]
+}

--- a/tests/validate_test.sh
+++ b/tests/validate_test.sh
@@ -96,7 +96,7 @@ load ../src/validate.sh
     [ "$status" -eq 0 ]
 }
 
-@test "validate_include_tests rejects empty string" {
+@test "validate_include_tests accepts empty string" {
     run validate_include_tests ""
     [ "$status" -eq 0 ]
 }
@@ -186,6 +186,42 @@ load ../src/validate.sh
 
 @test "validate_work_dir_path rejects path traversal" {
     run validate_work_dir_path "../etc" "/workspace"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: work-dir path must be within workspace"* ]]
+}
+
+@test "validate_output_file_path rejects absolute path" {
+    run validate_output_file_path "/etc/passwd" "/workspace"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: output-file path must be a relative path"* ]]
+}
+
+@test "validate_output_file_path rejects encoded traversal" {
+    run validate_output_file_path "%2e%2e/%2e%2e/etc" "/workspace"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: output-file path must be within workspace"* ]]
+}
+
+@test "validate_output_file_path rejects double-encoded traversal" {
+    run validate_output_file_path "..%252f..%252fetc" "/workspace"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: output-file path must be within workspace"* ]]
+}
+
+@test "validate_work_dir_path rejects absolute path" {
+    run validate_work_dir_path "/etc/passwd" "/workspace"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: work-dir path must be a relative path"* ]]
+}
+
+@test "validate_work_dir_path rejects encoded traversal" {
+    run validate_work_dir_path "%2e%2e/%2e%2e/etc" "/workspace"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error: work-dir path must be within workspace"* ]]
+}
+
+@test "validate_work_dir_path rejects double-encoded traversal" {
+    run validate_work_dir_path "..%252f..%252fetc" "/workspace"
     [ "$status" -eq 1 ]
     [[ "$output" == *"Error: work-dir path must be within workspace"* ]]
 }


### PR DESCRIPTION
This PR implements additional configuration options to bring this action in parity with govulncheck's CLI functionality. This includes a refactor to offload the action's functionality to shell scripts, including the addition of input and path validation, which also allows for better testing and maintainability. An update to the Renovate configuration is also included, as action dependencies weren't being updated.

## Changes

- Add new action inputs for all scan configuration options
- Add shell scripts: validate.sh, build-args.sh, fix-sarif.sh, and entrypoint.sh
- Add BATS tests for validate.sh, build-args.sh, fix-sarif.sh
- Add test.yml CI workflow with ShellCheck and bats tests
- Add SARIF post-processing fix for duplicate CVE tags
- Add .gitignore for test artifacts and IDE files
- Update renovate.json with GitHub Actions SHA pinning
- Rewrite README with comprehensive documentation
- Update action and setup-go versions to latest

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added several action inputs (caching, setup, scan/config options) and updated defaults; action now uses a unified entrypoint, includes input validation, and supports SARIF post-processing.
* **Documentation**
  * Restructured README with Quick Start, configuration tables, examples, and exit codes.
* **Chores**
  * Added Test & Lint CI workflow, updated Renovate rules, and expanded .gitignore.
* **Tests**
  * Added comprehensive test suites and ShellCheck configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->