### PR TITLE
ci(update-pinned-ref): make shell scripts executable before running

### DIFF
--- a/.github/actions/update-pinned-ref/action.yml
+++ b/.github/actions/update-pinned-ref/action.yml
@@ -26,6 +26,10 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Make scripts executable
+      shell: bash
+      run: chmod +x "${{ github.action_path }}/update-ref.sh" "${{ github.action_path }}/commit-and-push.sh"
+
     - name: Get SHA and update README
       id: update-readme
       shell: bash


### PR DESCRIPTION
This PR adds a step to make the shell scripts executable before running them in the GitHub Actions composite action, because the "Update Pinned Ref" workflow was failing with a "Permission denied" error when trying to execute shell scripts.

## Changes

- Add `chmod +x` step in action.yml to ensure scripts have execute permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed script execution permissions in automated GitHub Actions workflows to ensure reliable pipeline execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->