### PR TITLE
ci(renovate): enable vulnerability alerts and lockfile maintenance

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,19 +1,24 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices"],
-  "dependencyDashboard": true,
+  "extends": [
+    "config:best-practices",
+    ":enableVulnerabilityAlerts"
+  ],
   "automerge": true,
   "packageRules": [
     {
-      "description": "Automerge non-major updates",
-      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "description": "Automerge non-major + security updates (minor/patch/digest/security)",
+      "matchUpdateTypes": ["minor", "patch", "digest", "security"],
       "automerge": true
     },
     {
-      "description": "Update GitHub Actions with SHA pins",
+      "description": "Group all GitHub Actions updates into a single PR",
       "matchManagers": ["github-actions"],
-      "matchPackageNames": ["^actions/"],
-      "pinDigests": true
+      "groupName": "GitHub Actions",
+      "groupSlug": "github-actions"
     }
-  ]
+  ],
+  "lockFileMaintenance": {
+    "automerge": true
+  }
 }


### PR DESCRIPTION
This PR updates the Renovate configuration to remove redundant configuration options and implements security/vulnerability updates and lockfile maintenance while also grouping GH actions updates.

## Changes

- Add vulnerability alerts
- Add lockfile maintenance
- Group GH actions updates