### PR TITLE
ci(actions): set read-all workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,13 @@ on:
   push:
     branches: [master]
 
-permissions:
-  contents: write
+permissions: read-all
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd

--- a/.github/workflows/update-pinned-ref.yml
+++ b/.github/workflows/update-pinned-ref.yml
@@ -21,13 +21,14 @@ on:
   repository_dispatch:
     types: [release]
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: read-all
 
 jobs:
   update-ref:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd


### PR DESCRIPTION
This PR addresses security issues by setting base read-all permissions and moving write permissions to the job level.

## Changes

- Use read-all base permissions
- Move write permissions to job level