### PR TITLE
docs(readme): add badges and improve formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
+<!-- markdownlint-disable -->
+<div align="center">
+
 # govulncheck-action
 
+<!-- markdownlint-restore -->
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/nicholas-fedor/govulncheck-action/badge)](https://scorecard.dev/viewer/?uri=github.com/nicholas-fedor/govulncheck-action)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/31b33e083b1c48e0af7564d6fce1a78c)](https://app.codacy.com/gh/nicholas-fedor/govulncheck-action/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+![GitHub Tag](https://img.shields.io/github/v/tag/nicholas-fedor/govulncheck-action)
+![GitHub License](https://img.shields.io/github/license/nicholas-fedor/govulncheck-action)
+
+</div>
 
 A GitHub Action that runs [govulncheck](https://pkg.go.dev/golang.org/x/vuln/cmd/govulncheck) to detect known vulnerabilities in Go dependencies.
 


### PR DESCRIPTION
This PR improves the project README.md by centering the title and badges. It also adds assorted badges.

## Changes

- Center align title and badges
- Add Codacy, tag, and license badges

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Codacy, GitHub tag version, and GitHub license badges to the README alongside the existing OpenSSF Scorecard badge.
  * Updated README formatting and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->