### PR TITLE
fix(deps): add overrides for picomatch and tinyglobby

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4958,13 +4958,13 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=8.6"
+        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -5898,19 +5898,6 @@
         "picomatch": {
           "optional": true
         }
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/to-regex-range": {

--- a/package.json
+++ b/package.json
@@ -5,5 +5,9 @@
     "@commitlint/cli": "20.5.0",
     "@commitlint/config-conventional": "20.5.0",
     "semantic-release": "25.0.3"
+  },
+  "overrides": {
+    "picomatch": "4.0.4",
+    "tinyglobby": "0.2.16"
   }
 }


### PR DESCRIPTION
This PR resolves two high-severity npm vulnerability advisories by adding dependency overrides to force patched versions.

## Problem

The project had two open dependabot alerts for vulnerabilities in picomatch:
- CVE-2026-33671 (GHSA-c2c7-rcm5-vvqj) - ReDoS via extglob quantifiers (HIGH)
- CVE-2026-33672 (GHSA-3v7f-55p6-f55p) - Method Injection in POSIX Character Classes (Medium)

These were transitive dependencies from semantic-release's dependency tree.

## Solution

Added npm overrides to force:
- picomatch to 4.0.4 (contains security fixes)
- tinyglobby to 0.2.16 (uses fixed picomatch)

## Changes

- package.json: Added overrides section
- package-lock.json: Regenerated with overridden dependencies

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency resolution to ensure enhanced stability and compatibility across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->