### PR TITLE
fix(deps): sync package-lock.json with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2650,6 +2650,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/micromatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/mime": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-4.1.0.tgz",


### PR DESCRIPTION
This PR syncs the `package-lock.json` with the `package.json` after the previous updates and changes to overrides.

## Problem

The release workflow fails at `npm ci` with:

  Missing: picomatch@2.3.2 from lock file

This occurs because the lock file references dependencies that no longer
align with package.json after the dep updates.

## Solution

Run `npm install` to regenerate package-lock.json so it is in sync with
the current package.json, restoring `npm ci` functionality.

## Changes

- Updated package-lock.json to reflect current package.json dependencies